### PR TITLE
Password reset support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ export default class LoginScreen extends React.Component {
 
   render() {
     const b2cLogin = new B2CAuthentication({
+      tenant: 'yourtenant.onmicrosoft.com',
       client_id: CLIENT_ID,
       client_secret: "<key set in application/key>",
       user_flow_policy: "B2C_1_signupsignin",
+      reset_password_policy: 'B2C_1_password_reset',
       token_uri: "https://saroujetmp.b2clogin.com/saroujetmp.onmicrosoft.com/oauth2/v2.0/token",
       authority_host: "https://saroujetmp.b2clogin.com/saroujetmp.onmicrosoft.com/oauth2/v2.0/authorize",
       redirect_uri: "https://functionapp120190131041619.azurewebsites.net/.auth/login/aad/callback",


### PR DESCRIPTION
Add support for creating a password reset policy in an Azure B2C Tenant and handle the response back from the B2C SignupAndSignIn Policy and redirects to the specified password reset policy